### PR TITLE
Update make_hex_compatible to support existing tokens from v4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## 5.1.0
 - Removed `token_key` which was no longer necessary after removal of salt in 4.2.0
-- Fix old tokens not being accepted in 5.0.0, 5.0.1 and 5.0.2
+- Revert `make_hex_compatible` to original implementation in 4.2.0
+  - This change allows a clean upgrade from 4.2.0 -> 5.1.0 (existing tokens will continue to work)
+  - NOTE: This change will _not_ work with tokens generated in 5.0.* versions!
+- Updates local testing docker image and script
+  - Only tests python 3.12 by default - CI handles testing the entire matrix
 
 ## 5.0.2
 - Implement AUTO_REFRESH_MAX_TTL to limit total token lifetime when AUTO_REFRESH = True

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.12-slim-bullseye
+
+RUN apt-get update && apt-get install -y \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install tox
+
+WORKDIR /app

--- a/docker-run-tests.sh
+++ b/docker-run-tests.sh
@@ -1,3 +1,14 @@
 #!/usr/bin/env bash
 MOUNT_FOLDER=/app
-docker run --rm -it -v "$(pwd)":"$MOUNT_FOLDER" -w "$MOUNT_FOLDER" themattrix/tox
+
+docker build -t local-drk-tox-image .
+
+docker run --rm -it \
+  -v "$(pwd)/tests":"$MOUNT_FOLDER/tests" \
+  -v "$(pwd)/knox":"$MOUNT_FOLDER/knox" \
+  -v "$(pwd)/knox_project":"$MOUNT_FOLDER/knox_project" \
+  -v "$(pwd)/tox.ini":"$MOUNT_FOLDER/tox.ini" \
+  -v "$(pwd)/setup.py":"$MOUNT_FOLDER/setup.py" \
+  -v "$(pwd)/README.md":"$MOUNT_FOLDER/README.md" \
+  -v "$(pwd)/manage.py":"$MOUNT_FOLDER/manage.py" \
+  -w "$MOUNT_FOLDER" local-drk-tox-image tox

--- a/knox/crypto.py
+++ b/knox/crypto.py
@@ -14,10 +14,15 @@ def create_token_string() -> str:
 
 def make_hex_compatible(token: str) -> bytes:
     """
-    We need to make sure that the token, that is send is hex-compatible.
-    When a token prefix is used, we cannot guarantee that.
+    Ensure a token, which may contain a TOKEN_PREFIX, is hex-compatible before hashing.
     """
-    return binascii.unhexlify(binascii.hexlify(bytes(token, 'utf-8')))
+    try:
+        # use the original method for hashing a token pre v5.0.*
+        # this ensure tokens generated in v4.2 will remain valid in v5.1+
+        return binascii.unhexlify(token)
+    except (binascii.Error, ValueError):
+        # if a token has a prefix, encode it so that it's hex-compatible and can be hashed
+        return binascii.hexlify(token.encode('utf-8'))
 
 
 def hash_token(token: str) -> str:

--- a/knox/crypto.py
+++ b/knox/crypto.py
@@ -18,11 +18,11 @@ def make_hex_compatible(token: str) -> bytes:
     """
     try:
         # use the original method for hashing a token pre v5.0.*
-        # this ensure tokens generated in v4.2 will remain valid in v5.1+
+        # this ensures tokens generated in v4.2 will remain valid in v5.1+
         return binascii.unhexlify(token)
     except (binascii.Error, ValueError):
         # if a token has a prefix, encode it so that it's hex-compatible and can be hashed
-        return binascii.hexlify(token.encode('utf-8'))
+        return bytes(token, 'utf-8')
 
 
 def hash_token(token: str) -> str:


### PR DESCRIPTION
Hey @jmsmkn !

I agree with [your comment](https://github.com/jazzband/django-rest-knox/pull/362#issuecomment-2440814437) about keeping `token_key` around for now. If folks need to rollback to a prior version for whatever reason (i.e. on a failed deploy), keeping the field will make that rollback a lot easier. :)

I updated the docker script so that I could run unit tests locally (it seems like the original image being used hadn't been updated in several years - unless I was missing something? were you able to run unit tests locally?)

One thing I hadn't considered until now: making this update to `make_hex_compatible` will restore backwards compatibility for 4.2.0, but ironically, it'll break compatibility with any tokens generated in 5.0.* 🤦 

It might be worth discussing that in the thread, because I'd hate to cause additional upgrade pains 😅 I'm not sure what the best path forward is. We could add a new setting like `ALLOW_V4_2_TOKENS=True` that the `make_hex_compatible` (or `hash_token`) keys off of to decide how to hash the token? Or perhaps we just add a clear deprecation/incompatibility warning like they've done in the past and let end-users decide...or something else?

Curious to hear what you think - let me know if you have any suggestions for this PR!